### PR TITLE
Add support for RS485 Solax X3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.toml
+*.pyc

--- a/Inputs/SolaxX3RS485.py
+++ b/Inputs/SolaxX3RS485.py
@@ -1,0 +1,75 @@
+from pymodbus.client.sync import ModbusSerialClient
+from pymodbus.exceptions import ModbusException
+from twisted.internet import defer, reactor, protocol
+from twisted.web.client import Agent, readBody
+from pymodbus.constants import Defaults
+from twisted.web.http_headers import Headers
+from struct import unpack
+
+# import pprint
+# pp = pprint.PrettyPrinter(indent=4)
+
+Defaults.UnitId = 1
+
+def unsigned16(result, addr):
+    return result.getRegister(addr)
+
+def join_msb_lsb(msb, lsb):
+    return (msb << 16) | lsb
+
+class SolaxX3RS485(object):
+
+    ##
+    # Create a new class to fetch data from the Modbus interface of Solax inverters
+    def __init__(self, port, baudrate, parity, stopbits, timeout):
+        self.port = port
+        self.client = ModbusSerialClient(method="rtu", port=self.port, baudrate=baudrate, parity=parity,
+                                         stopbits=stopbits, timeout=timeout)
+        
+    def fetch(self, completionCallback):
+        result = self.client.read_input_registers(0X400, 53)
+        if isinstance(result, ModbusException):
+            print("Exception from SolaxX3RS485: {}".format(result))
+            return
+         
+        self.vals = {}
+        self.vals['name'] = self.port.replace("/dev/tty", "");
+        self.vals['Pv1 input voltage'] = unsigned16(result, 0) / 10
+        self.vals['Pv2 input voltage'] = unsigned16(result, 1) / 10
+        self.vals['Pv1 input current'] = unsigned16(result, 2) / 10
+        self.vals['Pv2 input current'] = unsigned16(result, 3) / 10
+        self.vals['Grid Voltage Phase 1'] = unsigned16(result, 4) / 10
+        self.vals['Grid Voltage Phase 2'] = unsigned16(result, 5) / 10
+        self.vals['Grid Voltage Phase 3'] = unsigned16(result, 6) / 10
+        self.vals['Grid Frequency Phase 1'] = unsigned16(result, 7) / 100
+        self.vals['Grid Frequency Phase 2'] = unsigned16(result, 8) / 100
+        self.vals['Grid Frequency Phase 3'] = unsigned16(result, 9) / 100
+        self.vals['Output Current Phase 1'] = unsigned16(result, 10) / 10
+        self.vals['Output Current Phase 2'] = unsigned16(result, 11) / 10
+        self.vals['Output Current Phase 3'] = unsigned16(result, 12) / 10
+        self.vals['Temperature'] = unsigned16(result, 13)
+        self.vals['Inverter Power'] = unsigned16(result, 14)
+        self.vals['RunMode'] = unsigned16(result, 15)
+        self.vals['Output Power Phase 1'] = unsigned16(result, 16)
+        self.vals['Output Power Phase 2'] = unsigned16(result, 17)
+        self.vals['Output Power Phase 3'] = unsigned16(result, 18)
+        self.vals['Total DC Power'] = unsigned16(result, 19)
+        self.vals['PV1 DC Power'] = unsigned16(result, 20)
+        self.vals['PV2 DC Power'] = unsigned16(result, 21)
+        self.vals['Fault value of Phase 1 Voltage'] = unsigned16(result, 22) / 10
+        self.vals['Fault value of Phase 2 Voltage'] = unsigned16(result, 23) / 10
+        self.vals['Fault value of Phase 3 Voltage'] = unsigned16(result, 24) / 10
+        self.vals['Fault value of Phase 1 Frequency'] = unsigned16(result, 25) / 100
+        self.vals['Fault value of Phase 2 Frequency'] = unsigned16(result, 26) / 100
+        self.vals['Fault value of Phase 3 Frequency'] = unsigned16(result, 27) / 100
+        self.vals['Fault value of Phase 1 DCI'] = unsigned16(result, 28) / 1000
+        self.vals['Fault value of Phase 2 DCI'] = unsigned16(result, 29) / 1000
+        self.vals['Fault value of Phase 3 DCI'] = unsigned16(result, 30) / 1000
+        self.vals['Fault value of PV1 Voltage'] = unsigned16(result, 31) / 10
+        self.vals['Fault value of PV2 Voltage'] = unsigned16(result, 32) / 10
+        self.vals['Fault value of Temperature'] = unsigned16(result, 33)
+        self.vals['Fault value of GFCI'] = unsigned16(result, 34) / 1000
+        self.vals['Total Yield'] = join_msb_lsb(unsigned16(result, 36), unsigned16(result, 35)) / 1000
+        self.vals['Yield Today'] = join_msb_lsb(unsigned16(result, 38), unsigned16(result, 37)) / 1000
+        
+        completionCallback(self.vals)

--- a/config-sample.toml
+++ b/config-sample.toml
@@ -22,6 +22,15 @@ inverters = ['solax1']
 #stopbits = 1
 #ports = ["/dev/ttyMainsMeter"]
 
+# Enable this section to scrape Modbus/RTU (RS485, "meter" connection in the manual) for Solax X3 inverters
+#[SolaxX3RS485]
+#poll_period = 10 # seconds
+#timeout = 1 # seconds
+#baud = 9600
+#parity = 'N'
+#stopbits = 1
+#ports = ["/dev/ttySolaxX3"]
+
 # Enable this section to output to EmonCMS
 #[emoncms]
 #timeout = 5 # seconds

--- a/power_scraper.py
+++ b/power_scraper.py
@@ -37,6 +37,7 @@ import traceback
 from Inputs.SolaxWifi import SolaxWifi
 from Inputs.SolaxModbus import SolaxModbus
 from Inputs.SDM630ModbusV2 import SDM630ModbusV2
+from Inputs.SolaxX3RS485 import SolaxX3RS485
 from Outputs.SolaxBatteryControl import SolaxBatteryControl
 from Outputs.EmonCMS import EmonCMS
 from Outputs.Influx2 import Influx2
@@ -127,6 +128,17 @@ if 'SDM630ModbusV2' in config:
 
     looperSDM630 = task.LoopingCall(inputActions, SDM630Meters)
     looperSDM630.start(config['SDM630ModbusV2']['poll_period'])
+
+if 'SolaxX3RS485' in config:
+    print("Setting up SolaxX3RS485")
+    SolaxRS485Meters = []
+    for meter in config['SolaxX3RS485']['ports']:
+        modbusMeter = SolaxX3RS485(meter, config['SolaxX3RS485']['baud'], config['SolaxX3RS485']['parity'],
+                                 config['SolaxX3RS485']['stopbits'], config['SolaxX3RS485']['timeout'])
+        SolaxRS485Meters.append(modbusMeter)
+
+    looperSolaxRS485 = task.LoopingCall(inputActions, SolaxRS485Meters)
+    looperSolaxRS485.start(config['SolaxX3RS485']['poll_period'])
 
 reactor.addSystemEventTrigger('before', 'shutdown', shutdown)
 


### PR DESCRIPTION
This adds a new Input module to read the Solax X3 registers directly from the RS485 interface. Note that I connected to the built-in RJ45 sockets on pins 4 and 5 as described in the "meter connection" in the manual:
<img width="608" alt="Screenshot 2021-06-03 at 01 00 03" src="https://user-images.githubusercontent.com/966001/120562692-305abc00-c407-11eb-919d-a916a7db5de1.png">

What seems really strange to me is that the register addresses are completely off compared to the TCP Modbus input. I had to loop over all possible addresses to find them. I also can't find any documentation on them, hence the many unlabeled registers (the ones I labeled are deduced from the values shown when dumping raw values). These 53 registers are the only ones that don't return an "illegal address" error.